### PR TITLE
logging

### DIFF
--- a/log/log_config.py
+++ b/log/log_config.py
@@ -1,0 +1,36 @@
+from pydantic import BaseModel
+from ..util.constants import Constants
+
+class LogConfig(BaseModel):
+    """
+    desc:
+        Logging configuration to be set for the server
+    credit: 
+        https://stackoverflow.com/questions/63510041/adding-python-logging-to-fastapi-endpoints-hosted-on-docker-doesnt-display-api
+    """
+
+    LOGGER_NAME: str = Constants.APP_NAME
+    LOG_FORMAT: str = "%(levelprefix)s | %(asctime)s | %(message)s"
+    LOG_LEVEL: str = "DEBUG"
+
+    # Logging config
+    version: int = 1
+    disable_existing_loggers: bool = False
+    formatters: dict = {
+        "default": {
+            "()": "uvicorn.logging.DefaultFormatter",
+            "fmt": LOG_FORMAT,
+            "datefmt": "%Y-%m-%d %H:%M:%S",
+        },
+    }
+    handlers: dict = {
+        "default": {
+            "formatter": "default",
+            "class": "logging.StreamHandler",
+            "stream": "ext://sys.stderr",
+        },
+
+    }
+    loggers: dict = {
+        LOGGER_NAME: {"handlers": ["default"], "level": LOG_LEVEL},
+    }

--- a/main.py
+++ b/main.py
@@ -3,8 +3,14 @@ from .food_classifier.food_classifier import FoodClassifier
 from .food_analyzer.food_analyzer import FoodAnalyzer
 from .request_models.input import Foods
 from .request_models.output import FoodClassification, IndividualFoodClassification, AnalyzeFoods
+from .log.log_config import LogConfig
+from .util.constants import Constants
 from fastapi import Depends, FastAPI
 from functools import lru_cache
+from logging.config import dictConfig
+from json import dumps
+import logging
+from logging import Logger
 
 app = FastAPI()
 
@@ -17,17 +23,54 @@ app = FastAPI()
 def get_food_classifier():
     return FoodClassifier()
 
+@lru_cache
+def get_logger():
+    dictConfig(LogConfig().model_dump())
+    return logging.getLogger(Constants.APP_NAME)
+
 @app.post("/classify-foods")
-async def classify_foods(foods: Foods, classifier: Annotated[FoodClassifier, Depends(get_food_classifier)]) -> FoodClassification:
+async def classify_foods(foods: Foods, 
+                         classifier: Annotated[FoodClassifier, Depends(get_food_classifier)],
+                         logger: Annotated[Logger, Depends(get_logger)]) -> FoodClassification:
+    
+    # log the length of the input so we can debug potential data 
+    # loss between the client and the server
+    inputLength = len(foods.listOfFoods)
+    logger.info(f"{classify_foods.__name__}: The length of the input list of foods is: {inputLength}")
+
+    # run the food classifier on the input list of foods
     classifiedList = classifier.classify_foods(foods.listOfFoods)
     classifiedList = [IndividualFoodClassification(name=e.name, type=e.type) for e in classifiedList]
+    
+    # log the length of the output of the classification run so 
+    # we can debug potential data loss that results from 
+    # classifying foods
+    outputLength = len(classifiedList)
+    logger.info(f"{classify_foods.__name__}: The length of the processed list is: {outputLength}")
+
+    # dump the output of classification so that it can be studied for
+    # optimization and expected behavior
+    logger.info(f"{classify_foods.__name__}: Processing result: {dumps([e.__dict__ for e in classifiedList])}")
+
     foodClassification = FoodClassification(classification=classifiedList)
     
     return foodClassification
 
 @app.post("/analyze-foods")
-async def analyze_foods(foods: Foods) -> AnalyzeFoods:
+async def analyze_foods(foods: Foods, logger: Annotated[Logger, Depends(get_logger)]) -> AnalyzeFoods:
+
+    # log the length of the input so we can debug potential data 
+    # loss between the client and the server
+    inputLength = len(foods.listOfFoods)
+    logger.info(f"{analyze_foods.__name__}: the length of the input list of foods is: {inputLength}")
+
+    # run the food analyzer on the input
     foodAnalyzer = FoodAnalyzer(foods.listOfFoods)
+
+    # dump the output of the food analyzer so that it can be studied for
+    # optimization and expected behavior
+    logger.info(f"{analyze_foods.__name__}: Processing result: {dumps(foodAnalyzer.__dict__)}")
+
     analyzeFoods = AnalyzeFoods(
         inputLength=foodAnalyzer.inputLength, 
         distinctCount=foodAnalyzer.distinctCount,

--- a/util/constants.py
+++ b/util/constants.py
@@ -1,0 +1,2 @@
+class Constants(object):
+    APP_NAME = "guttheory_server"


### PR DESCRIPTION
- added a logging facility so we can easily observe the behavior of our application
- logging configuration is stored in ```GutTheory/log/log_config.py```
- you can use the logger to write to fast api server logs 
- fast api server logs are messages that you can see in the terminal when your server is running
- you can put any data/value you want in your message
- think of logs as the equivalent of print statements for debugging python files but for server applications (e.g. web api)
- the logger is defined as a singleton using lru cache in ```GutTheory/main.py```
- lines of code that follow the pattern ```logger.info("...")``` are writing messages to the log